### PR TITLE
refactor(hexgl): remove leap motion controller support

### DIFF
--- a/HexGL/Build/index.html
+++ b/HexGL/Build/index.html
@@ -85,8 +85,6 @@
     <h4>Click anywhere to continue.</h4>
   </div>
 
-  <div id="leapinfo" style="display: none"></div>
-
   <script src="libs/leap-0.4.1.min.js"></script>
   <script src="libs/Three.dev.js"></script>
   <script src="libs/ShaderExtras.js"></script>

--- a/HexGL/Build/launch.coffee
+++ b/HexGL/Build/launch.coffee
@@ -37,8 +37,7 @@ u = bkcore.Utils.getURLParameter
 defaultControls = if bkcore.Utils.isTouchDevice() then 1 else 0
 
 s = [
-  ['controlType', ['KEYBOARD', 'TOUCH', 'LEAP MOTION CONTROLLER',
-    'GAMEPAD'], defaultControls, defaultControls, 'Controls: ']
+  ['controlType', ['KEYBOARD', 'TOUCH', 'GAMEPAD'], defaultControls, defaultControls, 'Controls: ']
   ['quality', ['LOW', 'MID', 'HIGH', 'VERY HIGH'], 3, 3, 'Quality: ']
   ['hud', ['OFF', 'ON'], 1, 1, 'HUD: ']
   ['godmode', ['OFF', 'ON'], 0, 1, 'Godmode: ']

--- a/HexGL/Build/launch.js
+++ b/HexGL/Build/launch.js
@@ -75,7 +75,10 @@ function checkIfImageExists(url) {
 
   defaultControls = bkcore.Utils.isTouchDevice() ? 1 : 0;
 
-  s = [['controlType', ['KEYBOARD', 'TOUCH', 'LEAP MOTION CONTROLLER', 'GAMEPAD'], defaultControls, defaultControls, 'Controls: '], ['quality', ['LOW', 'MID', 'HIGH', 'VERY HIGH'], 3, 3, 'Quality: '], ['hud', ['OFF', 'ON'], 1, 1, 'HUD: '], ['godmode', ['OFF', 'ON'], 0, 1, 'Godmode: ']];
+  s = [['controlType', ['KEYBOARD', 'TOUCH', 'GAMEPAD'], defaultControls, defaultControls, 'Controls: '], 
+      ['quality', ['LOW', 'MID', 'HIGH', 'VERY HIGH'], 3, 3, 'Quality: '], 
+      ['hud', ['OFF', 'ON'], 1, 1, 'HUD: '], 
+      ['godmode', ['OFF', 'ON'], 0, 1, 'Godmode: ']];
 
   _fn = function(a) {
     var e, f, _ref;


### PR DESCRIPTION
Remove Leap Motion controller support because it's not necessary and if the player selects this control type without having the actual controller, the game will be stuck attempting to connect to the LM server.